### PR TITLE
Move chokidar to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.2",
   "description": "I18n using template strings.",
   "main": "index.js",
-  "dependencies": {
+  "devDependencies": {
     "chokidar": "^2.0.4"
   },
   "repository": {


### PR DESCRIPTION
chokidar seems to be not required in production. Moving it to devDependencies will exclude when you are building your project with 
```bash
npm install --production
```